### PR TITLE
Syntax changes for sql queries are done

### DIFF
--- a/createtestconf.php
+++ b/createtestconf.php
@@ -145,7 +145,7 @@ $option3=mysqli_real_escape_string($conn_test,$_POST["option3"]);
 $option4=mysqli_real_escape_string($conn_test,$_POST["option4"]);
 
 
-$query="INSERT INTO $tablename (`question_id`, `question`, `answer`, `option1`, `option2`, `option3`, `option4`) VALUES (NULL,?,?,?,?,?,?)";
+$query="INSERT INTO `slueatrx_vocab`.`$tablename` (`question_id`, `question`, `answer`, `option1`, `option2`, `option3`, `option4`) VALUES (NULL,?,?,?,?,?,?)";
 
 			if (!($stmt = $conn_test->prepare($query))) {
 				 echo("Error description: " . $conn_test -> error);

--- a/maintest.php
+++ b/maintest.php
@@ -17,7 +17,7 @@ $tablename=mysqli_real_escape_string($conn_test,$userid."_".$testname);
 
 //fetch the questions from tablename
 
-$query="select * from ".$tablename." order by question_id";
+$query="select * from `slueatrx_vocab`.`$tablename` order by question_id";
 
 			if (!($stmt = $conn_test->prepare($query))) {
 				 echo("Error description: stmtprepare" . $conn_test -> error);


### PR DESCRIPTION
test name with spaces eg. hera pheri
were giving errors because it was accepting only single word.

Proper syntax was required to be corrected.